### PR TITLE
Match with the whole root instead of the start

### DIFF
--- a/04/Extras/Utilities.swift
+++ b/04/Extras/Utilities.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private let separator: Character = "."
+
 extension Array where Element: Hashable{
   var toSet: Set<Element> {
     Set(self)
@@ -16,7 +18,7 @@ extension String {
 
 func root(of symbolNames: [String]) -> [String] {
   symbolNames
-    .map{$0.split(separator: ".")}
+    .map{$0.split(separator: separator)}
     .compactMap(\.first)
     .map(String.init)
     .toSet
@@ -36,6 +38,6 @@ func subNodeNames(for name: String) -> [String] {
 func symbolNames(startingWith root: String) -> [String] {
   symbolNames
     .filter{symbolName in
-      symbolName.starts(with: root)
+      symbolName.split(separator: separator).first! == root
     }
 }

--- a/04/Extras/Utilities.swift
+++ b/04/Extras/Utilities.swift
@@ -35,9 +35,9 @@ func subNodeNames(for name: String) -> [String] {
 }
 
 
-func symbolNames(startingWith root: String) -> [String] {
+func symbolNames(startingWith nodes: String) -> [String] {
   symbolNames
     .filter{symbolName in
-      symbolName.split(separator: separator).first! == root
+      symbolName.split(separator: separator).starts(with: nodes.split(separator: separator))
     }
 }


### PR DESCRIPTION
Prevents matching with symbolNames with a root that starts with another root name.
(e.g. book - bookmark, map - mapping)

Please feel free to modify if there is a more conventional way of expressing this.